### PR TITLE
timing: Don't wait then abort without checking again.

### DIFF
--- a/Modbusino.cpp
+++ b/Modbusino.cpp
@@ -153,11 +153,11 @@ static int receive(uint8_t *req, uint8_t _slave)
         if (!Serial.available()) {
 	    i = 0;
 	    while (!Serial.available()) {
-		delay(1);
-		if (++i == 10) {
+		if (i++ == 10) {
 		    /* Too late, bye */
 		    return -1;
 		}
+		delay(1);
 	    }
         }
 


### PR DESCRIPTION
If you're looking for available bytes, you should check for available,
then if it's timed out, and _then_ wait and check again, not check,
wait, timeout.  The final step effectively waits for 1 loop less, and
needlessly blocks.  While this has very little impact at common baud
rates, and with the fixed loop counter in the current implementation, if
this loop counter is replaced with a baud rate appropriate timeout, you
can run into problems here due to overly eager "timeouts"
